### PR TITLE
Enforce 14-day package cooldown and update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Reduce exposure to npm supply-chain attacks by requiring package
+# versions to be at least 14 days old before installation.
+min-release-age=14

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,37 +56,37 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
-			"integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.2",
+				"@eslint/object-schema": "^3.0.5",
 				"debug": "^4.3.1",
-				"minimatch": "^10.2.1"
+				"minimatch": "^10.2.4"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
-			"integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.0"
+				"@eslint/core": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-			"integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
-			"integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -107,13 +107,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-			"integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.0",
+				"@eslint/core": "^1.2.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -121,25 +121,39 @@
 			}
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.1",
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
 				"@humanwhocodes/retry": "^0.4.0"
 			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -180,9 +194,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -217,9 +231,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -244,9 +258,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -310,18 +324,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
-			"integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.2",
-				"@eslint/config-helpers": "^0.5.2",
-				"@eslint/core": "^1.1.0",
-				"@eslint/plugin-kit": "^0.6.0",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -330,9 +344,9 @@
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^9.1.1",
+				"eslint-scope": "^9.1.2",
 				"eslint-visitor-keys": "^5.0.1",
-				"espree": "^11.1.1",
+				"espree": "^11.2.0",
 				"esquery": "^1.7.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -343,7 +357,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.1",
+				"minimatch": "^10.2.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -366,9 +380,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
-			"integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -398,9 +412,9 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
-			"integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -527,9 +541,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -658,13 +672,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -768,9 +782,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {


### PR DESCRIPTION
To proactively mitigate the risk of software supply chain attacks, this PR introduces a 14-day minimum release age requirement for all npm packages. This ensures we only install dependencies that have been vetted by the community over a two-week period.

Summary of Changes

- Configured `.npmrc` with `min-release-age=14` to block the installation of newly published packages.
- Re-ran `npm run regen-package-lock` 